### PR TITLE
Improve container-build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
       contents: read
     outputs:
       IMAGE_TAG: ${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
-      IMAGE_PATH_0: ghcr.io/${{ github.repository }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}-${{ github.run_number }}
+      IMAGE_PATH_0: ghcr.io/${{ github.repository }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - id: ct_image_tag
-      run: echo "IMAGE_TAG=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      run: echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
     - name: get image sha256
       id: image_sha256
       run: |
-        echo "IMAGE_SHA256_0=$(docker manifest inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} | jq --raw-output '.config.digest')" >> $GITHUB_OUTPUT
+        docker pull ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
+        echo "IMAGE_SHA256_0=$(docker images ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} --format '{{.Digest}}')" >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     outputs:
       IMAGE_TAG: ${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
-      IMAGE_PATH_0: ghcr.io/${{ github.repository }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
+      IMAGE_PATH_0: ghcr.io/${{ github.repository }}/${GITHUB_REPOSITORY#*/}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: get image sha256
       id: image_sha256
       run: |
-        echo "IMAGE_SHA256=$(docker inspect flarenetworklocal | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
+        echo "IMAGE_SHA256=$(docker inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }} | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,6 @@ jobs:
       run: |
         docker build --progress=plain --no-cache --build-arg ROSETTA_SRC=. --tag ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} -f ./server/Dockerfile .
         docker push ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
-    - name: get image sha256
-      id: image_sha256
-      run: |
-        docker pull ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
-        echo "IMAGE_SHA256_0=$(docker images ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} --format '{{.Digest}}')" >> $GITHUB_OUTPUT
-        cat $GITHUB_OUTPUT
 
 
   test-container-localflare-online:
@@ -69,7 +63,7 @@ jobs:
         START_ROSETTA_SERVER_AFTER_BOOTSTRAP: [true, false]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256_0 }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_TAG }}
         ports:
           - 9650:9650
           - 9651:9651
@@ -148,7 +142,7 @@ jobs:
         index: [1, 2, 3, 4, 5]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256_0 }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_TAG }}
         ports:
           - 9650:9650
           - 9651:9651

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       packages: write
     needs:
     - define-env
+    outputs:
+      IMAGE_SHA256: ${{ steps.image_sha256.outputs.IMAGE_SHA256 }}
     steps:
     - uses: actions/checkout@v3
     - uses: docker/setup-qemu-action@v2
@@ -47,6 +49,11 @@ jobs:
       run: |
         docker build --progress=plain --no-cache --build-arg ROSETTA_SRC=. --tag ${{ needs.define-env.outputs.IMAGE_PATH_0 }} -f ./server/Dockerfile .
         docker push ${{ needs.define-env.outputs.IMAGE_PATH_0 }}
+    - name: get image sha256
+      id: image_sha256
+      run: |
+        echo "IMAGE_SHA256=$(docker inspect flarenetworklocal | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
 
 
   test-container-localflare-online:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         index: [1, 2, 3, 4, 5]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256 }}
         ports:
           - 9650:9650
           - 9651:9651

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,15 @@ jobs:
       contents: read
     outputs:
       IMAGE_TAG: ${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
-      IMAGE_PATH_0: ghcr.io/${{ github.repository }}/${GITHUB_REPOSITORY#*/}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
+      IMAGE_PATH_0: ghcr.io/${{ github.repository }}/${{ steps.ct_image_tag.outputs.REPOSITORY_NAME }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - id: ct_image_tag
-      run: echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      run: |
+        echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
 
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Build and push container image
       shell: bash
       run: |
-        docker build --progress=plain --no-cache --build-arg ROSETTA_SRC=. --tag ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }} -f ./server/Dockerfile .
-        docker push ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
+        docker build --progress=plain --no-cache --build-arg ROSETTA_SRC=. --tag ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} -f ./server/Dockerfile .
+        docker push ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
     - name: get image sha256
       id: image_sha256
       run: |
-        echo "IMAGE_SHA256=$(docker inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }} | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
+        echo "IMAGE_SHA256=$(docker inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
 
 
   test-container-localflare-online:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,8 @@ jobs:
           --health-retries 10
           --health-start-period 30s
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v3
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go_version }}
     - run: sudo apt update -y && sudo apt install curl -y
@@ -166,10 +164,8 @@ jobs:
           --health-retries 10
           --health-start-period 30s
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v3
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go_version }}
     - run: sudo apt update -y && sudo apt install curl -y
@@ -193,8 +189,8 @@ jobs:
   test-make_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go_version }}
       - run: (cd server && make build)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
         fetch-depth: 0
     - id: ct_image_tag
       run: |
-        if [[ "${GITHUB_REF#refs/*/}" == "main" ]]; then echo "IMAGE_TAG=latest" >> $GITHUB_OUTPUT
-        else echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        TAG_NORMALIZED=$(echo ${GITHUB_REF#refs/*/} | sed "s/[^[:alpha:]0-9.-]/-/g")
+        if [[ "$TAG_NORMALIZED" == "main" ]]; then echo "IMAGE_TAG=latest" >> $GITHUB_OUTPUT
+        else echo "IMAGE_TAG=$TAG_NORMALIZED" >> $GITHUB_OUTPUT
         fi
         echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
       run: |
         docker build --progress=plain --no-cache --build-arg ROSETTA_SRC=. --tag ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} -f ./server/Dockerfile .
         docker push ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
+    - name: get image sha256
+      id: image_sha256
+      run: |
+        docker pull ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
+        export IMAGE_SHA256_0_FULL=$(docker image inspect --format='{{json .RepoDigests}}' registry.gitplac.si/aljaxus/fri-transfer/app:test | jq --raw-output '.[0]')
+        echo "IMAGE_SHA256_0=${IMAGE_SHA256_0_FULL#*@}" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
 
 
   test-container-localflare-online:
@@ -63,7 +70,7 @@ jobs:
         START_ROSETTA_SERVER_AFTER_BOOTSTRAP: [true, false]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_TAG }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256_0 }}
         ports:
           - 9650:9650
           - 9651:9651
@@ -142,7 +149,7 @@ jobs:
         index: [1, 2, 3, 4, 5]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_TAG }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256_0 }}
         ports:
           - 9650:9650
           - 9651:9651

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     outputs:
       IMAGE_TAG: ${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
-      IMAGE_PATH_0: ghcr.io/${{ github.repository }}/flare-rosetta:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}-${{ github.run_number }}
+      IMAGE_PATH_0: ghcr.io/${{ github.repository }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}-${{ github.run_number }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     outputs:
       IMAGE_TAG: ${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
-      IMAGE_PATH_0: ghcr.io/${{ github.repository }}/${{ steps.ct_image_tag.outputs.REPOSITORY_NAME }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
+      IMAGE_PATH_0: ghcr.io/${{ github.repository }}/${{ steps.ct_image_tag.outputs.REPOSITORY_NAME }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -47,13 +47,12 @@ jobs:
     - name: Build and push container image
       shell: bash
       run: |
-        docker build --progress=plain --no-cache --build-arg ROSETTA_SRC=. --tag ${{ needs.define-env.outputs.IMAGE_PATH_0 }} -f ./server/Dockerfile .
-        docker push ${{ needs.define-env.outputs.IMAGE_PATH_0 }}
+        docker build --progress=plain --no-cache --build-arg ROSETTA_SRC=. --tag ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }} -f ./server/Dockerfile .
+        docker push ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }}
     - name: get image sha256
       id: image_sha256
       run: |
-        echo "IMAGE_SHA256=$(docker inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }} | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
-        cat $GITHUB_OUTPUT
+        echo "IMAGE_SHA256=$(docker inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ steps.ct_image_tag.outputs.IMAGE_TAG }} | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
 
 
   test-container-localflare-online:
@@ -68,7 +67,7 @@ jobs:
         START_ROSETTA_SERVER_AFTER_BOOTSTRAP: [true, false]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256 }}
         ports:
           - 9650:9650
           - 9651:9651

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     needs:
     - define-env
     outputs:
-      IMAGE_SHA256: ${{ steps.image_sha256.outputs.IMAGE_SHA256 }}
+      IMAGE_SHA256_0: ${{ steps.image_sha256.outputs.IMAGE_SHA256_0 }}
     steps:
     - uses: actions/checkout@v3
     - uses: docker/setup-qemu-action@v2
@@ -52,7 +52,8 @@ jobs:
     - name: get image sha256
       id: image_sha256
       run: |
-        echo "IMAGE_SHA256=$(docker inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} | jq --raw-output '.[0].Id')" >> $GITHUB_OUTPUT
+        echo "IMAGE_SHA256_0=$(docker manifest inspect ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} | jq --raw-output '.config.digest')" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
 
 
   test-container-localflare-online:
@@ -67,7 +68,7 @@ jobs:
         START_ROSETTA_SERVER_AFTER_BOOTSTRAP: [true, false]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256 }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256_0 }}
         ports:
           - 9650:9650
           - 9651:9651
@@ -146,7 +147,7 @@ jobs:
         index: [1, 2, 3, 4, 5]
     services:
       flare_node:
-        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256 }}
+        image: ${{ needs.define-env.outputs.IMAGE_PATH_0 }}@${{ needs.build-container.outputs.IMAGE_SHA256_0 }}
         ports:
           - 9650:9650
           - 9651:9651

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
         docker pull ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
         export IMAGE_SHA256_0_FULL=$(docker image inspect --format='{{json .RepoDigests}}' ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} | jq --raw-output '.[0]')
         echo "IMAGE_SHA256_0=${IMAGE_SHA256_0_FULL#*@}" >> $GITHUB_OUTPUT
-        cat $GITHUB_OUTPUT
 
 
   test-container-localflare-online:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       id: image_sha256
       run: |
         docker pull ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }}
-        export IMAGE_SHA256_0_FULL=$(docker image inspect --format='{{json .RepoDigests}}' registry.gitplac.si/aljaxus/fri-transfer/app:test | jq --raw-output '.[0]')
+        export IMAGE_SHA256_0_FULL=$(docker image inspect --format='{{json .RepoDigests}}' ${{ needs.define-env.outputs.IMAGE_PATH_0 }}:${{ needs.define-env.outputs.IMAGE_TAG }} | jq --raw-output '.[0]')
         echo "IMAGE_SHA256_0=${IMAGE_SHA256_0_FULL#*@}" >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
         fetch-depth: 0
     - id: ct_image_tag
       run: |
-        echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        if [[ "${GITHUB_REF#refs/*/}" == "main" ]]; then echo "IMAGE_TAG=latest" >> $GITHUB_OUTPUT
+        else echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        fi
         echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
 
   build-container:


### PR DESCRIPTION
Previously container images were tagged with `{short commit sha}-{pipeline run}` which made sense while testing the workflow, but it doesn't in "production" where the latest tag should be updated and other tags should be created from git tags (versioned container images)

This PR fixes that;
- workflow runs for releases (tags) and non-main branches push images tagged accordingly; so a `1.0.0` git tag would push `1.0.0` container tag `feature-somethingsomething` would push `feature-somethingsomething` container tag ([example here](https://github.com/aljazs-flare/flare-rosetta/pkgs/container/flare-rosetta%2Fflare-rosetta))
- workflow runs for `main` branch push container images tagged as `latest`
- test jobs in the workflow do not reference container image with a tag, but with a digest - removing the possibility of tests being run on older container images that were somehow cached and not updated.